### PR TITLE
Update to GNOME 41 runtime

### DIFF
--- a/org.worldpossible.ScriptLauncher.yml
+++ b/org.worldpossible.ScriptLauncher.yml
@@ -1,6 +1,6 @@
 app-id: org.worldpossible.ScriptLauncher
 runtime: org.gnome.Platform
-runtime-version: '3.38'
+runtime-version: '41'
 sdk: org.gnome.Sdk
 command: worldpossible-scriptlauncher
 


### PR DESCRIPTION
The 3.38 runtime has been EOLed.
